### PR TITLE
Code Fix for Painting masks throws error #17

### DIFF
--- a/operators/image_props.py
+++ b/operators/image_props.py
@@ -61,6 +61,14 @@ class LP_OT_ImageProps(bpy.types.Operator):
 
         row = layout.row()
         row.enabled = False
+        row.label(text="Interpolation")
+
+        row = layout.row()
+        row.prop(tex, "interpolation", text="")
+        row.separator()
+
+        row = layout.row()
+        row.enabled = False
         row.label(text="Extension")
 
         row = layout.row()

--- a/operators/paint.py
+++ b/operators/paint.py
@@ -50,8 +50,13 @@ class LP_OT_PaintChannel(bpy.types.Operator):
 
         # create or get image
         if not tex.image:
-            img = utils_paint.create_image("image", self.resolution, self.color, channel.is_data)
-            tex.image = img
+            # Blanchsb code fix Dec2021: Painting masks throws error #17
+            if self.channel:
+                img = utils_paint.create_image("image", self.resolution, self.color, channel.is_data)
+                tex.image = img
+            else:
+                img = utils_paint.create_image("image", self.resolution, (0,0,0,1), False)
+                tex.image = img
         else:
             img = tex.image
 
@@ -65,7 +70,9 @@ class LP_OT_PaintChannel(bpy.types.Operator):
         layout.use_property_decorate = False
 
         layout.prop(self, "resolution")
-        layout.prop(self, "color")
+        # Blanchsb code fix Dec2021: Painting masks throws error #17
+        if self.channel:
+            layout.prop(self, "color")
 
     def invoke(self, context, event):
         # find tex node

--- a/operators/paint.py
+++ b/operators/paint.py
@@ -50,7 +50,6 @@ class LP_OT_PaintChannel(bpy.types.Operator):
 
         # create or get image
         if not tex.image:
-            # Blanchsb code fix Dec2021: Painting masks throws error #17
             if self.channel:
                 img = utils_paint.create_image("image", self.resolution, self.color, channel.is_data)
                 tex.image = img
@@ -70,7 +69,6 @@ class LP_OT_PaintChannel(bpy.types.Operator):
         layout.use_property_decorate = False
 
         layout.prop(self, "resolution")
-        # Blanchsb code fix Dec2021: Painting masks throws error #17
         if self.channel:
             layout.prop(self, "color")
 


### PR DESCRIPTION
Created a couple of checks If Channel exists when adding Paintable Image texture to Mix Color Mask.
Dec 24, 2021